### PR TITLE
Updates conventions and plan to include providers

### DIFF
--- a/CONVENTIONS.md
+++ b/CONVENTIONS.md
@@ -1,6 +1,8 @@
 # ✨ Serverlesspresso Crossplane Helm Project – Coding Conventions
 
-These conventions apply to the conversion of the Serverlesspresso SAM-based CloudFormation template into a Helm chart managed by Crossplane using Upbound AWS providers.
+These conventions apply to the conversion of the Serverlesspresso SAM-based
+CloudFormation template into a Helm chart managed by Crossplane using Upbound
+AWS providers.
 
 ---
 
@@ -62,6 +64,8 @@ These conventions apply to the conversion of the Serverlesspresso SAM-based Clou
 - Always use the latest stable version of the Upbound AWS providers.
 - Ensure each resource includes a valid `providerConfigRef.name`.
 - Avoid using `deletionPolicy: Orphan` unless necessary.
+- Assure that the apropriate provider is included in the `cloud-providers`
+  chart whenever you introduce a new resource.
 
 ---
 

--- a/prompt-plan.md
+++ b/prompt-plan.md
@@ -29,7 +29,7 @@ Output should be clean YAML and support templating via `.Values`. Don’t includ
 ## ✅ Prompt 2: Define the EventBridge Bus (Crossplane)
 
 ```
-Write a Crossplane `aws.eventbridge.EventBus` resource using Upbound's provider-aws.
+Write a Crossplane `aws.eventbridge.EventBus` resource using Upbound's provider-family-aws and any providers in that family that are necessary.
 
 The name should be templated via `.Values.appName`. The resource should be defined as a Helm template.
 


### PR DESCRIPTION
TL;DR
-----

Uses CONVENTIONS.md and our prompt-plan.md to assure all providers
are incldued in the `cloud-providers` chart

Details
-------

Reviewing the prompt plan and to do list I realized that the guidance
they providered my result in providers being left out of the overall
application. This change updates the plan and conventions to induce the
model to include all providers.
