### PR TITLE
Corrects the `apiVersion` for our `ProviderConfig`

### DIFF
--- a/charts/cloud-providers/templates/aws-provider-config.yaml
+++ b/charts/cloud-providers/templates/aws-provider-config.yaml
@@ -1,4 +1,4 @@
-apiVersion: upbound.io/v1beta1
+apiVersion: aws.upbound.io/v1beta1
 kind: ProviderConfig
 metadata:
   name: {{ .Values.providers.aws.providerConfig.name }}

--- a/charts/cloud-providers/templates/service-account.yaml
+++ b/charts/cloud-providers/templates/service-account.yaml
@@ -19,4 +19,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: {{ include "cloud-providers.fullname" . }}-sa
-  namespace: ${{ .Release.Namespace }}
+  namespace: {{ .Release.Namespace }}

--- a/charts/cloud-providers/templates/service-account.yaml
+++ b/charts/cloud-providers/templates/service-account.yaml
@@ -1,8 +1,8 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: ${{ include "cloud-providers.fullname" . }}-sa
-  namespace: ${{ .Release.Namespace }}
+  name: {{ include "cloud-providers.fullname" . }}-sa
+  namespace: {{ .Release.Namespace }}
   labels:
     {{- include "cloud-providers.labels" . | nindent 4 }}
 ---

--- a/charts/cloud-providers/templates/service-account.yaml
+++ b/charts/cloud-providers/templates/service-account.yaml
@@ -18,5 +18,5 @@ roleRef:
   name: crossplane-view
 subjects:
 - kind: ServiceAccount
-  name: ${{ include "cloud-providers.fullname" . }}-sa
+  name: {{ include "cloud-providers.fullname" . }}-sa
   namespace: ${{ .Release.Namespace }}


### PR DESCRIPTION
TL;DR
-----

Fixes error that our assistant made with the `ProviderConfig`
resource

Details
-------

Repairs a defect where our assistant made a mistake in the
`apiVersion` for the `ProviderConfig` resource, assuming it was
`upbound.io/v1beta1` when it was supposed to be
`aws.upbound.io/v1beta1`.
