### PR TITLE
Adds requires service account and role binding

### DIFF
--- a/charts/cloud-providers/templates/aws-wait.yaml
+++ b/charts/cloud-providers/templates/aws-wait.yaml
@@ -11,7 +11,7 @@ spec:
   template:
     spec:
       restartPolicy: Never
-      serviceAccountName: {{ .Values.providers.aws.waitJob.serviceAccountName | default .Values.providers.serviceAccountName }}
+      serviceAccountName: {{ .Values.providers.aws.waitJob.serviceAccountName | print (include "cloud-providers.fullname" .) "-sa" }}
       containers:
         - name: {{ include "cloud-providers.fullname" . }}-wait-for-provider-aws
           image: bitnami/kubectl:latest

--- a/charts/cloud-providers/templates/service-account.yaml
+++ b/charts/cloud-providers/templates/service-account.yaml
@@ -1,0 +1,22 @@
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: ${{ include "cloud-providers.fullname" . }}-sa
+  namespace: ${{ .Release.Namespace }}
+  labels:
+    {{- include "cloud-providers.labels" . | nindent 4 }}
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: crossplane-view
+  labels:
+    {{- include "cloud-providers.labels" . | nindent 4 }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: crossplane-view
+subjects:
+- kind: ServiceAccount
+  name: ${{ include "cloud-providers.fullname" . }}-sa
+  namespace: ${{ .Release.Namespace }}


### PR DESCRIPTION
TL;DR
-----

Lets the AWS wait job run by satisfying RBAc requirements

Details
-------

Corrects and error where the AWS wait job was not running able to
access the Crossplane resources it needed to observe because of
insufficient permissions. Addresses the issue by creating a
service acccount that has read only access to the Crossplane
resources.
